### PR TITLE
fix: Update to shiply-sdk@1.4.4 with corrected TypeScript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^3.2.1",
-        "shiply-sdk": "^1.4.3",
+        "shiply-sdk": "^1.4.4",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -7405,9 +7405,9 @@
       }
     },
     "node_modules/shiply-sdk": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/shiply-sdk/-/shiply-sdk-1.4.3.tgz",
-      "integrity": "sha512-DZTEHLYXPTnwi4ItD5s7GNy39B/rQPs4Ib5lb1n8Vq4uRDEn8WkPg9Px3ih/DJuEreqtERYSWaBmHK9ItaB7Yg==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/shiply-sdk/-/shiply-sdk-1.4.4.tgz",
+      "integrity": "sha512-j9vzeXcYWVL83qVUsDcrd1B9M+fi5040S5BI5Yfdhr7ddQaJawwAX4EldgAuosZkvgq0xaMmB0u7uuxdjgAYSg==",
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^3.2.1",
-    "shiply-sdk": "^1.4.3",
+    "shiply-sdk": "^1.4.4",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -169,7 +169,7 @@ function ApiSettings() {
                     <Label>Integration Code</Label>
                     <div className="bg-muted p-4 rounded-md text-sm font-mono">
                         <div className="text-green-400">{'// Install the package'}</div>
-                        <div className="text-yellow-300">npm install shiply-sdk@1.4.3</div>
+                        <div className="text-yellow-300">npm install shiply-sdk@1.4.4</div>
                         <div className="mt-4 text-green-400">{'// Import and use the component'}</div>
                         <div className="text-blue-400">import ShiplyFeedback from &apos;shiply-sdk&apos;;</div>
                         <div className="mt-2 text-blue-400">function App() &#123;</div>


### PR DESCRIPTION
- Update package.json to use shiply-sdk@1.4.4
- Update settings page integration example to show correct version
- SDK now has proper default export TypeScript declarations
- Build now succeeds without TypeScript errors